### PR TITLE
Fix: Main video loop only creating one video

### DIFF
--- a/main.py
+++ b/main.py
@@ -241,7 +241,7 @@ def mainVideoLoop(data):
         createVideo(quoteText, bgMusic, bgVideo, i, ttsAudio)
         cleanUpAfterVideoFinished()
         print("finished! video: ", i)
-        return True
+    return True
 
 
 def changeJsonValue(question, data, dataString):


### PR DESCRIPTION
**Issue**: Program only created a single video even if "amountOfVideosToMake" was set to a different value.

**Cause**: mainVideoLoop had a return statement inside the for loop responsible for making "amountOfVideosToMake" videos.

**Fix**: Move "return True" outside of above mentioned for loop.